### PR TITLE
sendKeys API support array params

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea
 node_modules
 coverage
 doc

--- a/lib/browser.js
+++ b/lib/browser.js
@@ -1086,18 +1086,28 @@ const Browser = PromiseClass.create({
      * send keys to browser
      * @method sendKeys
      * @public
-     * @param  {String} text
+     * @param  {String/Array} texts
      * @param  {Function} done callback function
      */
-    sendKeys(text, done){
-        let self = this;
-        let Keys = self.Keys;
-        text = text.replace(/{(\w+)}/g, function(all, name){
-            let key = Keys[name.toUpperCase()];
-            return key?key:all;
+        sendKeys(texts, done){
+        let self = this,
+            Keys = self.Keys,
+            value = [];
+
+        if(!Array.isArray(texts)){
+            texts = [texts];
+        }
+
+        texts.forEach(function(text){
+            text = text.replace(/{(\w+)}/g, function(all, name){
+                let key = Keys[name.toUpperCase()];
+                return key?key:all;
+            });
+            value = value.concat(text.split(''));
         });
+
         self.execStrict('sendKeys', {}, {
-            value: text.split('')
+            value: value
         }, done);
     },
 

--- a/lib/elements.js
+++ b/lib/elements.js
@@ -454,18 +454,28 @@ const Elements = PromiseClass.create({
      * send keys to element
      * @method sendKeys
      * @public
-     * @param  {String} text
+     * @param  {String/Array} texts
      * @param  {Function} done callback function
      */
-    sendKeys(text, done){
-        let self = this;
-        let Keys = self._browser.Keys;
-        text = text.replace(/{(\w+)}/g, function(all, name){
-            let key = Keys[name.toUpperCase()];
-            return key?key:all;
+        sendKeys(texts, done){
+        let self = this,
+            Keys = self._browser.Keys,
+            value = [];
+
+        if(!Array.isArray(texts)){
+            texts = [texts];
+        }
+
+        texts.forEach(function(text){
+            text = text.replace(/{(\w+)}/g, function(all, name){
+                let key = Keys[name.toUpperCase()];
+                return key ? key : all;
+            });
+            value = value.concat(text.split(''));
         });
+
         self.execStrict('!sendElementKeys', {}, {
-            value: text.split('')
+            value: value
         }, done);
     },
 


### PR DESCRIPTION
Both support Array and String type.
```
browser.sendKeys("text");

browser.sendKeys(['{CTRL}', '{ALT}', '{SHIFT}', 'A', '{SHIFT}', '{ALT}', '{CTRL}']);
```