### PR TITLE
added option to get element id by new W3C standard needed by GeckoDri…

### DIFF
--- a/lib/elements.js
+++ b/lib/elements.js
@@ -48,7 +48,7 @@ const Elements = PromiseClass.create({
                         done(error);
                     }
                     else{
-                        self.elementIds = [ret.value.ELEMENT];
+                        self.elementIds = [ret.value.ELEMENT || ret.value['element-6066-11e4-a52e-4f735466cecf']];
                         self.length = 1;
                         done();
                     }
@@ -77,7 +77,7 @@ const Elements = PromiseClass.create({
                     let arrElements = ret.value;
                     if(arrElements.length > 0){
                         let elementIds = arrElements.map(function(element){
-                            return element.ELEMENT;
+                            return element.ELEMENT || element['element-6066-11e4-a52e-4f735466cecf'];
                         });
                         self.elementIds = elementIds;
                         self.length = elementIds.length;
@@ -873,7 +873,7 @@ const Elements = PromiseClass.create({
             else{
                 let arrELEMENTS = ret.value;
                 let elementIds = arrELEMENTS.map(function(ELEMENT){
-                    return ELEMENT.ELEMENT;
+                    return ELEMENT.ELEMENT || ELEMENT['element-6066-11e4-a52e-4f735466cecf'];
                 });
                 let elements = new Elements(self._browser, 'elements', elementIds);
                 elements.init();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jwebdriver2",
-  "version": "2.2.5",
+  "version": "1.0",
   "description": "A webdriver client for node.js",
   "homepage": "",
   "main": "./index",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jwebdriver2",
-  "version": "1.0",
+  "version": "1.0.0",
   "description": "A webdriver client for node.js",
   "homepage": "https://github.com/lkende/jWebDriver2#readme",
   "main": "./index",

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "jwebdriver",
+  "name": "jwebdriver2",
   "version": "2.2.5",
   "description": "A webdriver client for node.js",
-  "homepage": "http://jwebdriver.com/",
+  "homepage": "",
   "main": "./index",
   "dependencies": {
     "node-zip": "1.1.1",
@@ -52,7 +52,7 @@
     "await",
     "hosts"
   ],
-  "author": "Yanis Wang",
+  "author": "Luke Kende",
   "license": "MIT",
   "engines": {
     "node": ">= 4"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "jwebdriver2",
   "version": "1.0",
   "description": "A webdriver client for node.js",
-  "homepage": "",
+  "homepage": "https://github.com/lkende/jWebDriver#readme",
   "main": "./index",
   "dependencies": {
     "node-zip": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "jwebdriver2",
   "version": "1.0",
   "description": "A webdriver client for node.js",
-  "homepage": "https://github.com/lkende/jWebDriver#readme",
+  "homepage": "https://github.com/lkende/jWebDriver2#readme",
   "main": "./index",
   "dependencies": {
     "node-zip": "1.1.1",
@@ -33,10 +33,10 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/yaniswang/jWebDriver.git"
+    "url": "git://github.com/lkende/jWebDriver2.git"
   },
   "bugs": {
-    "url": "https://github.com/yaniswang/jWebDriver/issues"
+    "url": "https://github.com/lkende/jWebDriver2/issues"
   },
   "keywords": [
     "jwebdriver",


### PR DESCRIPTION
…ver with Firefox: Instead of attribute 'ELEMENT' the new standard specifies attribute 'element-6066-11e4-a52e-4f735466cecf'